### PR TITLE
Fix: worker graceful shutdown

### DIFF
--- a/etha/worker/state/sync.py
+++ b/etha/worker/state/sync.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import multiprocessing as mp
+import signal
 from itertools import groupby
 from queue import Empty
 from typing import Callable
@@ -58,6 +59,7 @@ class _SyncProc:
 
 def _sync_loop(data_dir: str, updates_queue: mp.Queue, new_chunks_queue: mp.Queue):
     init_logging()
+    signal.signal(signal.SIGINT, signal.SIG_IGN)
     while True:
         upd = updates_queue.get()
         StateFolder(data_dir).apply_update(


### PR DESCRIPTION
1) Ignore SIGINT in all spawned threads.
2) Spawn the main asyncio event loop in a new thread, so that uvicorn does not register its signal handlers.
3) Just sleep in the main thread and wait for `KeyboardInterrupt` to stop the uvicorn server.