### PR TITLE
handle INVALID traces from arbitrum networks

### DIFF
--- a/etha/ingest/tables.py
+++ b/etha/ingest/tables.py
@@ -306,7 +306,7 @@ class TraceTableBuilder(TableBuilderBase):
 
             trace_type: Literal['create', 'call', 'suicide']
             frame_type = frame['type']
-            if frame_type in ('CALL', 'CALLCODE', 'STATICCALL', 'DELEGATECALL'):
+            if frame_type in ('CALL', 'CALLCODE', 'STATICCALL', 'DELEGATECALL', 'INVALID'):
                 trace_type = 'call'
             elif frame_type in ('CREATE', 'CREATE2'):
                 trace_type = 'create'


### PR DESCRIPTION
this kind of trace was noticed on all arbitrum networks (one, goerli, nova)
https://nova.arbiscan.io/vmtrace?txhash=0x28d39f6d1b5bf1c3ce2de3f33d8b8f7d5eab77a639461a83187aecedfc98a849&type=gethtrace2