### PR TITLE
make receipt.effectiveGasPrice optional

### DIFF
--- a/etha/ingest/model.py
+++ b/etha/ingest/model.py
@@ -80,7 +80,7 @@ class Receipt(TypedDict):
     blockHash: Hash32
     blockNumber: Qty
     cumulativeGasUsed: Qty
-    effectiveGasPrice: Qty
+    effectiveGasPrice: NotRequired[Qty]
     gasUsed: Qty
     contractAddress: NotRequired[Address20]
     logs: list[Log]

--- a/etha/ingest/tables.py
+++ b/etha/ingest/tables.py
@@ -131,7 +131,7 @@ class TxTableBuilder(TableBuilderBase):
         if receipt:
             self.gas_used.append(receipt['gasUsed'])
             self.cumulative_gas_used.append(receipt['cumulativeGasUsed'])
-            self.effective_gas_price.append(receipt['effectiveGasPrice'])
+            self.effective_gas_price.append(receipt.get('effectiveGasPrice'))
             self.type.append(qty2int(receipt['type']))
             self.status.append(qty2int(receipt['status']))
             self.contract_address.append(receipt.get('contractAddress'))


### PR DESCRIPTION
> `eth_getTransactionReceipt` doesn't include `effectiveGasPrice`. Will include once EIP1559 is implemented
https://github.com/0xPolygonHermez/zkevm-node/blob/develop/docs/json-rpc-endpoints.md

`effectiveGasPrice` is not available for polygon zkevm yet. we also need to change its type in squid-sdk
https://github.com/search?q=repo%3Asubsquid%2Fsquid-sdk%20effectiveGasPrice&type=code