### PR TITLE
Update tx root validation for Arbitrum networks

### DIFF
--- a/sqa/eth/ingest/util.py
+++ b/sqa/eth/ingest/util.py
@@ -201,7 +201,7 @@ def transactions_root(transactions: list[Transaction]) -> str:
                 qty2int(tx['depositValue']),
                 qty2int(tx['gasPrice']),
                 qty2int(tx['gas']),
-                decode_hex(tx['retryTo']) if tx['retryTo'] else b'',
+                decode_hex(tx['retryTo']) if 'retryTo' in tx else b'',
                 qty2int(tx['retryValue']),
                 decode_hex(tx['beneficiary']),
                 qty2int(tx['maxSubmissionFee']),


### PR DESCRIPTION
Cannot find blocks with transactions of type `0x65` (101, ArbitrumUnsignedTxType) and `0x66` (102, ArbitrumContractTxType) and verify verification, so part related to them is commented. 

Sources: [Arbitrum docs](https://docs.arbitrum.io/arbos/geth#transaction-types), [Arbitrum Nitro docs for devs](https://nitro-docs-delta.vercel.app/for-devs/concepts/differences-between-arbitrum-ethereum/rpc-methods#transaction-types), [Arbitrum source files](https://github.com/OffchainLabs/go-ethereum/blob/7503143fd13f73e46a966ea2c42a058af96f7fcf/core/types/arb_types.go)