### PR TITLE
Set empty params for `eth_blockNumber` call

### DIFF
--- a/sqa/eth/ingest/ingest.py
+++ b/sqa/eth/ingest/ingest.py
@@ -126,7 +126,7 @@ class Ingest:
             self._chain_height = await self._get_chain_height()
 
     async def _get_chain_height(self) -> int:
-        hex_height = await self._rpc.call('eth_blockNumber')
+        hex_height = await self._rpc.call('eth_blockNumber', [])
         height = int(hex_height, 0)
         return max(height - self._finality_confirmation, 0)
 


### PR DESCRIPTION
Found that we call `eth_blockNumber` with `null` value as params, but in most cases it should be `[]`. I don't know why we haven't had any issues before, but it is Ok to update it anyway. I found that Shardeum Sphinx won't work with `null` as params, so it will fix this too.