### PR TITLE
Starknet: fix traces

### DIFF
--- a/sqa/starknet/writer/tables.py
+++ b/sqa/starknet/writer/tables.py
@@ -166,7 +166,7 @@ class TraceTableBuilder(TableBuilder):
         self.call_type.append(tx_trace.get('call_type'))
         self.class_hash.append(tx_trace.get('class_hash'))
         self.entry_point_selector.append(tx_trace.get('entry_point_selector'))
-        self.entry_point_type.append(tx_trace.get('entry'))
+        self.entry_point_type.append(tx_trace.get('entry_point_type'))
         self.revert_reason.append(tx_trace.get('revert_reason'))
         self.calldata.append(tx_trace.get('calldata'))
         self.result.append(tx_trace.get('result'))

--- a/tests/starknet/data/0000702000/0000702000-0000702100-e5dde/state_updates.parquet
+++ b/tests/starknet/data/0000702000/0000702000-0000702100-e5dde/state_updates.parquet
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:74418eedc204306fc9ff2291b98a2fcc59ccbc448c752e3a44343bd00061f560
-size 40878
+oid sha256:b7c94d8b0d49737076c68dda3a4397144fa2ae5f4cbbcd0c3caf3075309f3bc5
+size 40813

--- a/tests/starknet/data/0000702000/0000702000-0000702100-e5dde/traces.parquet
+++ b/tests/starknet/data/0000702000/0000702000-0000702100-e5dde/traces.parquet
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a9f46c6aec70961d185ecc833709ee80da5297b6398c9e1f99b68fa1d5f16f69
-size 2440999
+oid sha256:f43922870bd7accfc2aaf70daa5b9ca67d233639b0fed52669aaadc2f6068895
+size 2441484

--- a/tests/starknet/fixtures/state_update/result.json
+++ b/tests/starknet/fixtures/state_update/result.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5f72074aaa520bb35c9a4dc1f7b682820cb55109085a0586ffa5b2e3e5fa494f
+oid sha256:4fe0098ba8d815253ba661b285f5bc5e899d2d542092ee0f5eb168286f8a6f51
 size 3942

--- a/tests/starknet/fixtures/traces/result.json
+++ b/tests/starknet/fixtures/traces/result.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:310620c3c4ea6b06633c393837dba8fa5e3ea1b1c0dca0bdb6a4762c4a3709e3
-size 32356
+oid sha256:e400ae6136e3d9e41ca0881b776b95483750c7793601fd7c1a94d3cf70c0b9e2
+size 32512


### PR DESCRIPTION
Fix old typo that caused empty entry_point_type to be written in traces